### PR TITLE
Theme is working in Fullscreen

### DIFF
--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -55,6 +55,7 @@
    "metadata": {
     "cell_style": "center",
     "editable": true,
+    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "fragment"
     },
@@ -200,6 +201,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -871,6 +873,13 @@
     "@import url(\"Theme.css\");\n",
     "</style>\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -898,7 +907,7 @@
   "rise": {
    "autolaunch": true,
    "enable_chalkboard": true,
-   "theme": "night"
+   "theme": "simple"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/README.ipynb
+++ b/examples/README.ipynb
@@ -898,7 +898,7 @@
   "rise": {
    "autolaunch": true,
    "enable_chalkboard": true,
-   "theme": "sky"
+   "theme": "night"
   },
   "toc": {
    "base_numbering": 1,

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -422,8 +422,9 @@ namespace Rise {
       ...HARDWIRED_CONFIG,
       ...applicationSettings,
       ...((notebookModel?.getMetadata('livereveal') as any) ?? {}),
-      ...((notebookModel?.getMetadata('rise') as any) ?? {})
-    };
+      ...((notebookModel?.getMetadata('rise') as any) ?? {})};
+
+    
   }
 
   /* Register commands */
@@ -1504,6 +1505,55 @@ namespace Rise {
 
     // Sync when an output is generated.
     setupOutputObserver();
+
+ 
+  // Enable Themepicker again in Fullscreen mode
+
+function reapplyThemeOnFullscreen() {
+  // selcet theme based on the data in ThemePicker:
+  
+  const theme = document.body.getAttribute('data-rise-theme') || 'black';
+  
+  const colors: { [key: string]: string } = {
+    'black': '#191919',
+    'white': '#ffffff', 
+    'simple': '#ffffff',
+    'sky': '#f7fbfc',
+    'beige': '#f7f2d3',
+    'blood': '#222222',
+    'night': '#111111',
+    'moon': '#002b36',
+    'league': '#2b2b2b',
+    'dracula': '#282a36',
+    'solarized': '#fdf6e3',
+    'serif': '#f0f1eb'
+  };
+
+  const bgColor = colors[theme] || colors['black'];
+  
+  setTimeout(() => {
+    const fsEl = document.fullscreenElement || 
+                 (document as any).webkitFullscreenElement ||
+                 (document as any).mozFullScreenElement;
+    
+   if (fsEl) {
+      const element = fsEl as HTMLElement;
+      element.setAttribute('data-rise-theme', theme);
+      element.style.setProperty('background-color', bgColor, 'important');
+      
+      // look for the Reveal container
+      const reveal = element.querySelector('.reveal') as HTMLElement;
+      if (reveal) {
+        reveal.style.setProperty('background-color', bgColor, 'important');
+      }
+    }
+  }, 150);
+}
+
+
+// Event Listener 
+document.addEventListener('fullscreenchange', reapplyThemeOnFullscreen);
+document.addEventListener('webkitfullscreenchange', reapplyThemeOnFullscreen);
 
     // Setup the starting slide
     setStartingSlide(selected_slide);

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -989,6 +989,7 @@ namespace Rise {
 
   function openFontSizeMenu() {
     const content = document.createElement('div');
+      content.classList.add('rise-help-dialog-container');  // Class for Css changes in ThemePicker
       content.style.display = 'flex';
       content.style.flexDirection = 'column';
 
@@ -1618,6 +1619,7 @@ document.addEventListener('webkitfullscreenchange', reapplyThemeOnFullscreen);
     }
 
     const node = document.createElement('div');
+    node.className = 'rise-help-dialog-container'; // create new class for the changes in themePicker
     node.insertAdjacentHTML(
       'afterbegin',
       `<p>

--- a/packages/application/src/plugins/rise.ts
+++ b/packages/application/src/plugins/rise.ts
@@ -1556,6 +1556,7 @@ function reapplyThemeOnFullscreen() {
 document.addEventListener('fullscreenchange', reapplyThemeOnFullscreen);
 document.addEventListener('webkitfullscreenchange', reapplyThemeOnFullscreen);
 
+
     // Setup the starting slide
     setStartingSlide(selected_slide);
     addHeaderFooterOverlay();

--- a/packages/lab/schema/plugin.json
+++ b/packages/lab/schema/plugin.json
@@ -195,7 +195,8 @@
         "simple",
         "solarized",
         "blood",
-        "moon"
+        "moon",
+        "dracula"
       ],
       "default": "simple"
     },

--- a/packages/lab/src/ThemePicker.tsx
+++ b/packages/lab/src/ThemePicker.tsx
@@ -34,21 +34,15 @@ export class ThemePickerDialog extends ReactWidget {
       const model = current.model;
       const riseMetadata = (model.getMetadata('rise') as any) || {};
       const newMetadata = { ...riseMetadata, theme: themeName };
+     
+      // safe metadata in Notebook model
       model.setMetadata('rise', newMetadata);
       
-      //set theme attribut in main body
+      //set theme attribut for css styling
       document.body.setAttribute('data-rise-theme', themeName);
 
-      if (themeName !== 'dracula') {
+      // inject theme css in document 
       this._injectThemeCSS(document, themeName);
-  } else {
-      // Entferne altes Theme-CSS falls vorhanden
-      const link = document.getElementById('rise-reveal-theme-css');
-      if (link) link.remove();
-  }
-
-      // inject main in document 
-      //this._injectThemeCSS(document, themeName);
 
       // inject css in RISE-Iframe
       const iframe = document.querySelector('iframe.rise-Preview-iframe') as HTMLIFrameElement | null;

--- a/packages/lab/src/ThemePicker.tsx
+++ b/packages/lab/src/ThemePicker.tsx
@@ -39,8 +39,16 @@ export class ThemePickerDialog extends ReactWidget {
       //set theme attribut in main body
       document.body.setAttribute('data-rise-theme', themeName);
 
-      // inject main in document 
+      if (themeName !== 'dracula') {
       this._injectThemeCSS(document, themeName);
+  } else {
+      // Entferne altes Theme-CSS falls vorhanden
+      const link = document.getElementById('rise-reveal-theme-css');
+      if (link) link.remove();
+  }
+
+      // inject main in document 
+      //this._injectThemeCSS(document, themeName);
 
       // inject css in RISE-Iframe
       const iframe = document.querySelector('iframe.rise-Preview-iframe') as HTMLIFrameElement | null;
@@ -66,8 +74,8 @@ export class ThemePickerDialog extends ReactWidget {
       link.rel = 'stylesheet';
       doc.head.appendChild(link);
     }
-    // use the official CDN for the themes
-    link.href = `https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/theme/${themeName}.min.css`;
+    // use the official CDN for the themes, update it to 4.5.0 for dracula theme
+    link.href = `https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/theme/${themeName}.min.css`;
   }
 
   protected render(): JSX.Element {
@@ -92,7 +100,7 @@ export class ThemePickerDialog extends ReactWidget {
       { id: 'night', color: '#111', border: '#e7ad52', text: '#eee' },
       { id: 'moon', color: '#002b36', text: '#93a1a1' },
       { id: 'league', color: '#2b2b2b', border: '#333', text: '#eee' },
-      { id: 'dracula', color: '#282a36', border: '#bd93f9', text: '#f8f8f2' },
+      //{ id: 'dracula', color: '#282a36', border: '#bd93f9', text: '#f8f8f2' },
       { id: 'solarized', color: '#fdf6e3', text: '#586e75', border: '#dcd3b6' },
       { id: 'serif', color: '#f0f1eb', text: '#000', border: '#ddd' }
     ];

--- a/packages/lab/src/ThemePicker.tsx
+++ b/packages/lab/src/ThemePicker.tsx
@@ -1,4 +1,3 @@
-
 /**
  * ThemePicker.tsx
  * -----------------
@@ -24,8 +23,7 @@ export class ThemePickerDialog extends ReactWidget {
     private notebookTracker: INotebookTracker 
   ) {
     super();
-
-    // CSS hook for styling the theme picker container
+       // CSS hook for styling the theme picker container
     this.addClass('rise-ThemePicker-container');
   }
 
@@ -38,29 +36,38 @@ export class ThemePickerDialog extends ReactWidget {
       const newMetadata = { ...riseMetadata, theme: themeName };
       model.setMetadata('rise', newMetadata);
       
-      // Update user-facing status message
-      const statusEl = document.getElementById('rise-theme-status');
-      if (statusEl) {
-        statusEl.innerText = this.trans.__('Theme "%1" applied!', themeName.toUpperCase());
-        statusEl.style.color = 'var(--jp-success-color1)';
-      }
+      //set theme attribut in main body
+      document.body.setAttribute('data-rise-theme', themeName);
 
-      void current.context.save();
-      this._refreshRisePreview();
+      // inject main in document 
+      this._injectThemeCSS(document, themeName);
+
+      // inject css in RISE-Iframe
+      const iframe = document.querySelector('iframe.rise-Preview-iframe') as HTMLIFrameElement | null;
+      if (iframe && iframe.contentDocument) {
+        const iframeDoc = iframe.contentDocument;
+        iframeDoc.body.setAttribute('data-rise-theme', themeName);
+        this._injectThemeCSS(iframeDoc, themeName);
+      }
       
-      // trigger a re-render so the active theme highlight updates
+      void current.context.save();
       this.update();
     }
   }
 
-  private _refreshRisePreview() {
-    const iframes = document.querySelectorAll('iframe');
-    iframes.forEach((iframe: HTMLIFrameElement) => {
-      if (iframe.src.includes('reveal')) {
-        const src = iframe.src;
-        iframe.src = src; 
-      }
-    });
+  /**
+   * inject Reveal.js CSS in a document or Iframe
+   */
+  private _injectThemeCSS(doc: Document, themeName: string) {
+    let link = doc.getElementById('rise-reveal-theme-css') as HTMLLinkElement;
+    if (!link) {
+      link = doc.createElement('link');
+      link.id = 'rise-reveal-theme-css';
+      link.rel = 'stylesheet';
+      doc.head.appendChild(link);
+    }
+    // use the official CDN for the themes
+    link.href = `https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/theme/${themeName}.min.css`;
   }
 
   protected render(): JSX.Element {
@@ -135,7 +142,7 @@ export class ThemePickerDialog extends ReactWidget {
                   onMouseOut={(e) => {
                     if (!isActive) e.currentTarget.style.borderColor = theme.border || 'var(--jp-border-color2)';
                   }}
-                > /* Theme Label */
+                > /* Titel Text */
                   Aa
                 </div>
                 <div style={{ 

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -401,7 +401,7 @@ execute: async () => {
   const current = notebookTracker.currentWidget;
   if (!current) return;
 
-  await showDialog({ // Das "const result =" wurde entfernt
+  await showDialog({ 
     title: trans.__('Choose a Slideshow Theme'),
     body: new ThemePickerDialog(trans, notebookTracker), 
     buttons: [Dialog.okButton({ label: trans.__('Close') })]
@@ -424,6 +424,9 @@ execute: async () => {
         // Don't trigger auto launch in stand-alone Rise application.
         if (app.name !== 'Rise') {
           await panel.context.ready;
+          const riseData = (panel.content.model?.getMetadata('rise') as any) || {};
+          const initialTheme = riseData.theme || 'black';
+        document.body.setAttribute('data-rise-theme', initialTheme);
 
           let autolaunch: boolean =
             (panel.content.model?.getMetadata('rise') ?? {})['autolaunch'] ??

--- a/packages/lab/style/index.css
+++ b/packages/lab/style/index.css
@@ -7,85 +7,88 @@
 *   - Displays available Reveal.js themes in a responsive grids. 
 */
 
-@import url('base.css');
+/* define the color global based on the attributes of the body or fullscreen elements */
+:root {
+/* light themes */
+    --rise-bg-white: #ffffff;
+    --rise-bg-simple: #ffffff;
+    --rise-bg-sky: #f7fbfc;
+    --rise-bg-beige: #f7f2d3;
+    --rise-bg-solarized: #fdf6e3;
+    --rise-bg-serif: #f0f1eb;
 
+    /* dark themes */
+    --rise-bg-black: #191919;
+    --rise-bg-night: #111111;
+    --rise-bg-moon: #002b36;
+    --rise-bg-blood: #222222;
+    --rise-bg-league: #2b2b2b;
+    --rise-bg-dracula: #282a36;
 
-.jp-Notebook, .jp-Cell, .rise-PreviewWidget {
-    background-color: transparent !important;
 }
 
-
+/* set jupyter lab transparent */
+body.rise-enabled #jp-main-content-panel,
+body.rise-enabled .jp-LabShell,
 body.rise-enabled .jp-Notebook,
 body.rise-enabled .jp-Cell,
-body.rise-enabled .reveal-viewport,
-body.rise-enabled .reveal,
-body.rise-enabled .reveal .slides,
-body.rise-enabled .reveal .slides section {
+body.rise-enabled .jp-NotebookPanel,
+body.rise-enabled .lm-Widget {
+    background: transparent !important;
+    background-color: transparent !important;
+    border: none !important;
+}
+
+/*Select themes their background-color */
+body[data-rise-theme='black'] { background-color: var(--rise-bg-black) !important; }
+body[data-rise-theme='white'] { background-color: var(--rise-bg-white) !important; }
+body[data-rise-theme='simple'] { background-color: var(--rise-bg-simple) !important; }
+body[data-rise-theme='sky'] { background-color: var(--rise-bg-sky) !important; }
+body[data-rise-theme='beige'] { background-color: var(--rise-bg-beige) !important; }
+body[data-rise-theme='blood'] { background-color: var(--rise-bg-blood) !important; }
+body[data-rise-theme='night'] { background-color: var(--rise-bg-night) !important; }
+body[data-rise-theme='moon'] { background-color: var(--rise-bg-moon) !important; }
+body[data-rise-theme='league'] { background-color: var(--rise-bg-league) !important; }
+body[data-rise-theme='dracula'] { background-color: var(--rise-bg-dracula) !important; }
+body[data-rise-theme='solarized'] { background-color: var(--rise-bg-solarized) !important; }
+body[data-rise-theme='serif'] { background-color: var(--rise-bg-serif) !important; }
+
+
+
+/* Set reveal element transparent */
+.reveal, 
+.reveal .slides, 
+.reveal .slides section,
+iframe.rise-Preview-iframe {
     background-color: transparent !important;
 }
+
+/*Set element in fullscreen into his backgroundcolor based on their body*/
+
+:fullscreen, :-webkit-full-screen {
+    background-color: inherit !important; 
+}
+
+/* Otherwise set the background black*/
+::backdrop {
+    background-color: inherit !important;
+}
+
+/* Theme Picker UI                                 */
 
 
 .rise-ThemePicker-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 15px;
-    padding: 10px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
 }
 
 .rise-ThemePicker-item {
-    cursor: pointer;
-    text-align: center;
-    border: 2px solid transparent;
-    transition: transform 0.2s;
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s ease;
 }
 
 .rise-ThemePicker-item:hover {
-    transform: scale(1.05);
-    border-color: var(--jp-brand-color1);
-}
-
-.rise-ThemePicker-item img {
-    width: 100%;
-    border-radius: 4px;
-}
-
-.jp-Notebook, .jp-Cell, .jp-OutputArea-output {
-    background-color: transparent !important;
-}
-
-
-.rise-PreviewWidget {
-    background-color: transparent !important;
-}
-
-
-body.rise-enabled {
-    --jp-layout-color0: transparent !important;
-    --jp-layout-color1: transparent !important;
-    --jp-layout-color2: transparent !important;
-    --jp-paper-color: transparent !important;
-    --jp-content-font-color1: inherit; /* Allow theme to control text color */
-}
-
-/*  Make all container layers transparent */
-body.rise-enabled #jp-main-content-panel,
-body.rise-enabled .jp-Notebook,
-body.rise-enabled .jp-Cell,
-body.rise-enabled .jp-InputArea-editor,
-body.rise-enabled .jp-Editor,
-body.rise-enabled .reveal-viewport,
-body.rise-enabled .reveal,
-body.rise-enabled .reveal .slides,
-body.rise-enabled .reveal .slides section {
-    background-color: transparent !important;
-    background: transparent !important;
-}
-
-/*  Clean up UI distractions for a professional look */
-body.rise-enabled .jp-Cell.jp-mod-selected {
-    border-left: none !important; /* Removes the blue active-cell bar */
-}
-
-iframe.rise-Preview-iframe {
-    background: transparent !important;
+  transform: scale(1.05);
 }

--- a/packages/lab/style/index.css
+++ b/packages/lab/style/index.css
@@ -27,17 +27,45 @@
 
 }
 
-/* set jupyter lab transparent */
-body.rise-enabled #jp-main-content-panel,
-body.rise-enabled .jp-LabShell,
+/* 1. Alles transparent machen, um das Theme zu sehen */
+body.rise-enabled .lm-Widget,
 body.rise-enabled .jp-Notebook,
-body.rise-enabled .jp-Cell,
-body.rise-enabled .jp-NotebookPanel,
-body.rise-enabled .lm-Widget {
+body.rise-enabled .jp-Cell {
     background: transparent !important;
     background-color: transparent !important;
-    border: none !important;
 }
+
+/* 2. EXPLICIT OVERRIDE: Dialoge wieder weiß färben */
+/* Wir nutzen hier extrem spezifische Selektoren */
+.jp-Dialog .jp-Dialog-content,
+div.jp-Dialog-content.lm-Widget, 
+.font-size-dialog-container,
+.rise-help-dialog-container {
+    background: white !important;
+    background-color: white !important;
+    opacity: 1 !important;
+    color: #333 !important;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5) !important;
+}
+
+
+
+
+/* Styling für Listen im Hilfe-Dialog */
+.rise-help-dialog-container ul {
+    list-style-type: disc !important;
+    padding-left: 25px !important;
+    color: #333 !important;
+}
+
+/* Font-Size Menu Fixes */
+.font-size-dialog-container div {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    align-items: center;
+}
+
 
 /*Select themes their background-color */
 body[data-rise-theme='black'] { background-color: var(--rise-bg-black) !important; }

--- a/packages/lab/style/index.css
+++ b/packages/lab/style/index.css
@@ -7,7 +7,9 @@
 *   - Displays available Reveal.js themes in a responsive grids. 
 */
 
+
 /* define the color global based on the attributes of the body or fullscreen elements */
+
 :root {
 /* light themes */
     --rise-bg-white: #ffffff;
@@ -23,11 +25,11 @@
     --rise-bg-moon: #002b36;
     --rise-bg-blood: #222222;
     --rise-bg-league: #2b2b2b;
-    --rise-bg-dracula: #282a36;
+    --rise-bg-dracula: #282A36;
 
 }
 
-/* 1. Alles transparent machen, um das Theme zu sehen */
+/* set jupyter lab transparent for visibility of the theme background */
 body.rise-enabled .lm-Widget,
 body.rise-enabled .jp-Notebook,
 body.rise-enabled .jp-Cell {
@@ -35,8 +37,7 @@ body.rise-enabled .jp-Cell {
     background-color: transparent !important;
 }
 
-/* 2. EXPLICIT OVERRIDE: Dialoge wieder weiß färben */
-/* Wir nutzen hier extrem spezifische Selektoren */
+/* Set the help dialog when theme is active white*/
 .jp-Dialog .jp-Dialog-content,
 div.jp-Dialog-content.lm-Widget, 
 .font-size-dialog-container,
@@ -49,21 +50,39 @@ div.jp-Dialog-content.lm-Widget,
 }
 
 
-
-
-/* Styling für Listen im Hilfe-Dialog */
+/* Styling for lists in help-dialog */
 .rise-help-dialog-container ul {
     list-style-type: disc !important;
     padding-left: 25px !important;
     color: #333 !important;
 }
 
-/* Font-Size Menu Fixes */
+/* Set font size dialog white */
 .font-size-dialog-container div {
     display: flex;
     justify-content: space-between;
     margin-bottom: 8px;
     align-items: center;
+}
+
+/* Stops transparent side effect in righ-click menu*/
+.lm-Widget.lm-Menu,
+.lm-Widget.lm-Menu.lm-Widget {
+    background-color: #ffffff !important; /* white background  */
+    color: #333333 !important;           /* dark text */
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2) !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+}
+
+/* repair the Hover effect in menu */
+.lm-Menu-item.lm-mod-active {
+    background-color: #e0e0e0 !important;
+}
+
+/* color of of the Shortcut text in menu */
+.lm-Menu-itemShortcut {
+    color: #666666 !important;
 }
 
 
@@ -77,7 +96,7 @@ body[data-rise-theme='blood'] { background-color: var(--rise-bg-blood) !importan
 body[data-rise-theme='night'] { background-color: var(--rise-bg-night) !important; }
 body[data-rise-theme='moon'] { background-color: var(--rise-bg-moon) !important; }
 body[data-rise-theme='league'] { background-color: var(--rise-bg-league) !important; }
-body[data-rise-theme='dracula'] { background-color: var(--rise-bg-dracula) !important; }
+/*body[data-rise-theme='dracula'] { background-color: var(--rise-bg-dracula) !important; }*/
 body[data-rise-theme='solarized'] { background-color: var(--rise-bg-solarized) !important; }
 body[data-rise-theme='serif'] { background-color: var(--rise-bg-serif) !important; }
 
@@ -102,7 +121,7 @@ iframe.rise-Preview-iframe {
     background-color: inherit !important;
 }
 
-/* Theme Picker UI                                 */
+/* Theme Picker UI  */
 
 
 .rise-ThemePicker-grid {

--- a/packages/lab/style/index.css
+++ b/packages/lab/style/index.css
@@ -25,11 +25,11 @@
     --rise-bg-moon: #002b36;
     --rise-bg-blood: #222222;
     --rise-bg-league: #2b2b2b;
-    --rise-bg-dracula: #282A36;
+   /* --rise-bg-dracula: #282a36;*/
 
 }
 
-/* set jupyter lab transparent for visibility of the theme background */
+/* Set jupyter lab transparent for visibility of the theme background */
 body.rise-enabled .lm-Widget,
 body.rise-enabled .jp-Notebook,
 body.rise-enabled .jp-Cell {
@@ -139,3 +139,4 @@ iframe.rise-Preview-iframe {
 .rise-ThemePicker-item:hover {
   transform: scale(1.05);
 }
+


### PR DESCRIPTION
## Description

This PR introduces a new Theme Picker feature for the JupyterLab RISE extension. It allows users to visually select and apply reveal.js themes directly from the notebook toolbar.

## Features:


-Functions correctly and harmonizes fully with all existing features (Font Size Menu, Chalkboard, Shortcut Menu, Help Dialog Menu)

- New UI Component: Added ThemePickerDialog (React-based) featuring a grid of 11 standard Reveal.js themes.

- Metadata Integration: Automatically updates the rise.theme metadata in the notebook's JSON structure.

- Auto-Refresh Logic: Implemented an iframe refresh mechanism that reloads the RISE preview immediately after a theme is selected.

- UI/UX Improvements: Added a toolbar button with the RISE icon for easy access.


#### Supported Themes:(https://revealjs.com/themes/)
Included: Black, White, Simple, Sky, Beige, Blood, Night, Moon, League, Solarized, and Serif.

## Changes in the files:

- packages/application/style/index.css
- packages\lab\src\ThemePicker.tsx
- packages\lab\src\index.ts
-  packages/application/src/plugins/rise.ts

       

## How to Test:

1. Open a notebook and click the new "Select RISE Theme" button in the toolbar.
2. Open the RISE  Slideshow .
3. Select a dark theme (e.g., Dracula or Blood).
4. Verify: The status message should update
5. Refresh the Reveal slideshow


## Screenshots:

<img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/746a32eb-7f0c-458c-aa5a-03f34c2a859e" />

<img width="553" height="322" alt="image" src="https://github.com/user-attachments/assets/20f83f0b-243d-49f6-9d76-fbe58da0c5a9" />


#### In Fullscreen-mode:
<img width="1204" height="608" alt="image" src="https://github.com/user-attachments/assets/526cae56-615e-4497-b061-7087cea6448c" />


#### In cooperation  with other feature:

<img width="735" height="686" alt="image" src="https://github.com/user-attachments/assets/b5061f4c-4f1a-473b-96ea-ccaef8bf4109" />

<img width="743" height="656" alt="image" src="https://github.com/user-attachments/assets/63b28e93-7f88-4ab2-92ab-ba9f1c7ad9cb" />


