### PR TITLE
files added for themepicker

### DIFF
--- a/packages/lab/src/ThemePicker.tsx
+++ b/packages/lab/src/ThemePicker.tsx
@@ -1,0 +1,165 @@
+/**
+ * ThemePicker.tsx
+ * -----------------
+ * A React-based JupyterLab widget that allows users to select and apply
+ * a Reveal.js (RISE) presentation theme to the currently active notebook.
+ *
+ * PURPOSE:
+ * - Provide a visual theme picker UI for RISE presentations
+ * - Update the notebook's `rise.theme` metadata
+ * - Persist the change and refresh the RISE preview immediately
+ *
+ * USAGE:
+ * - The widget updates metadata of the currently active notebook only
+ */
+
+import { ReactWidget } from '@jupyterlab/apputils';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import React from 'react';
+
+export class ThemePickerDialog extends ReactWidget {
+  constructor(
+    private trans: any,
+    private notebookTracker: INotebookTracker 
+  ) {
+    super();
+       // CSS hook for styling the theme picker container
+    this.addClass('rise-ThemePicker-container');
+  }
+
+  private updateMetadata(themeName: string) {
+    const current = this.notebookTracker.currentWidget;
+    
+    if (current && current.model) {
+      const model = current.model;
+      const riseMetadata = (model.getMetadata('rise') as any) || {};
+      const newMetadata = { ...riseMetadata, theme: themeName };
+     
+      // safe metadata in Notebook model
+      model.setMetadata('rise', newMetadata);
+      
+      //set theme attribut for css styling
+      document.body.setAttribute('data-rise-theme', themeName);
+
+      // inject theme css in document 
+      this._injectThemeCSS(document, themeName);
+
+      // inject css in RISE-Iframe
+      const iframe = document.querySelector('iframe.rise-Preview-iframe') as HTMLIFrameElement | null;
+      if (iframe && iframe.contentDocument) {
+        const iframeDoc = iframe.contentDocument;
+        iframeDoc.body.setAttribute('data-rise-theme', themeName);
+        this._injectThemeCSS(iframeDoc, themeName);
+      }
+      
+      void current.context.save();
+      this.update();
+    }
+  }
+
+  /**
+   * inject Reveal.js CSS in a document or Iframe
+   */
+  private _injectThemeCSS(doc: Document, themeName: string) {
+    let link = doc.getElementById('rise-reveal-theme-css') as HTMLLinkElement;
+    if (!link) {
+      link = doc.createElement('link');
+      link.id = 'rise-reveal-theme-css';
+      link.rel = 'stylesheet';
+      doc.head.appendChild(link);
+    }
+    // use the official CDN for the themes, update it to 4.5.0 for dracula theme
+    link.href = `https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.5.0/theme/${themeName}.min.css`;
+  }
+
+  protected render(): JSX.Element {
+    
+    const currentWidget = this.notebookTracker.currentWidget;
+    const currentMetadata = (currentWidget?.model?.getMetadata('rise') as any) || {};
+    const activeTheme = currentMetadata.theme || 'black'; 
+     /** Available Reveal.js themes
+     * Each entry defines:
+     * - id: theme name
+     * - color: preview background
+     * - text: preview text color
+     * - border: optional border color
+     */
+    const themes = [
+      { id: 'black', color: '#111', text: '#eee' },
+      { id: 'white', color: '#fff', text: '#222', border: '#ddd' },
+      { id: 'simple', color: '#fff', text: '#000', border: '#eee' },
+      { id: 'sky', color: '#add8e6', text: '#000' },
+      { id: 'beige', color: '#f7f2d3', text: '#333' },
+      { id: 'blood', color: '#222', border: '#800000', text: '#eee' },
+      { id: 'night', color: '#111', border: '#e7ad52', text: '#eee' },
+      { id: 'moon', color: '#002b36', text: '#93a1a1' },
+      { id: 'league', color: '#2b2b2b', border: '#333', text: '#eee' },
+      //{ id: 'dracula', color: '#282a36', border: '#bd93f9', text: '#f8f8f2' },
+      { id: 'solarized', color: '#fdf6e3', text: '#586e75', border: '#dcd3b6' },
+      { id: 'serif', color: '#f0f1eb', text: '#000', border: '#ddd' }
+    ];
+
+    return (
+      <div className="rise-ThemePicker-container" style={{ padding: '10px' }}>
+        <div id="rise-theme-status" style={{ 
+          textAlign: 'center', marginBottom: '15px', fontSize: '13px', fontWeight: 'bold', minHeight: '1.2em' 
+        }}>
+          {this.trans.__('Current theme: %1', activeTheme.toUpperCase())}
+        </div>
+        
+        <div className="rise-ThemePicker-grid" style={{ 
+          display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '12px' 
+        }}>
+          {themes.map(theme => {
+            const isActive = theme.id === activeTheme;
+            return (
+              <div 
+                key={theme.id} 
+                className="rise-ThemePicker-item"
+                onClick={() => this.updateMetadata(theme.id)}
+                style={{ cursor: 'pointer', textAlign: 'center' }}
+              >
+                <div 
+                  style={{ 
+                    width: '100%', 
+                    height: '50px', 
+                    backgroundColor: theme.color, 
+                    borderRadius: '6px', 
+                    
+                    border: isActive 
+                      ? '3px solid var(--jp-brand-color1)' 
+                      : `1px solid ${theme.border || 'var(--jp-border-color2)'}`,
+                    boxShadow: isActive ? '0 0 8px var(--jp-brand-color1)' : 'none',
+                    transition: 'all 0.2s',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    color: theme.text || '#fff',
+                    fontSize: '12px',
+                    fontWeight: 'bold'
+                  }}
+                  onMouseOver={(e) => {
+                    if (!isActive) e.currentTarget.style.borderColor = 'var(--jp-brand-color1)';
+                  }}
+                  onMouseOut={(e) => {
+                    if (!isActive) e.currentTarget.style.borderColor = theme.border || 'var(--jp-border-color2)';
+                  }}
+                > /* Titel Text */
+                  Aa
+                </div>
+                <div style={{ 
+                  marginTop: '5px', 
+                  fontSize: '10px', 
+                  fontWeight: isActive ? 'bold' : 'normal',
+                  color: isActive ? 'var(--jp-brand-color1)' : 'inherit'
+                }}>
+                  {theme.id.toUpperCase()}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -1,3 +1,20 @@
+/**
+ * 
+ * Index.ts
+ * 
+ * Purpose:
+ *   - Provides commands, toolbar buttons, and UI integration for Reveal.js
+ *     slideshow presentations inside JupyterLab.
+ *   - Supports theme selection
+ *
+ * Usage:
+ *   - Loads automatically as a JupyterLab extension.
+ *   - Users can open notebooks in RISE mode, apply themes
+ *
+ * Notes:
+ *   - Depends on `ThemePickerDialog` for theme selection.
+ *   - Integrates with notebook metadata to persist RISE settings.
+ */
 import {
   ILayoutRestorer,
   JupyterFrontEnd,
@@ -8,6 +25,7 @@ import {
   CommandToolbarButton,
   ICommandPalette,
   showDialog,
+  Dialog,
   WidgetTracker
 } from '@jupyterlab/apputils';
 
@@ -36,6 +54,12 @@ import { IRisePreviewFactory, IRisePreviewTracker } from './tokens';
 
 export { IRisePreviewFactory, IRisePreviewTracker } from './tokens';
 
+// new class fpr the Theme pcikcer dialog:
+import { ThemePickerDialog } from './ThemePicker';
+
+import { paletteIcon } from '@jupyterlab/ui-components';
+
+import '../style/index.css';
 /**
  * Command IDs namespace for JupyterLab RISE extension
  */
@@ -53,6 +77,12 @@ namespace CommandIDs {
    * Set the slide attribute of a cell
    */
   export const riseSetSlideType = 'RISE:set-slide-type';
+/* set the theme*/ 
+  export const riseSetTheme = 'RISE:set-theme';
+
+  // picks the theme
+export const openThemePicker = 'RISE:theme-picker';
+
 }
 
 const factory: JupyterFrontEndPlugin<IRisePreviewFactory> = {
@@ -334,6 +364,51 @@ const plugin: JupyterFrontEndPlugin<IRisePreviewTracker> = {
         )
     });
 
+    /*new theme command*/
+
+  commands.addCommand(CommandIDs.riseSetTheme, {
+  label: args => trans.__('Set Slideshow Theme: %1', args['theme']),
+  execute: args => {
+    const themeName = args['theme'] as string;
+    const current = notebookTracker.currentWidget;
+    if (current && themeName) {
+      const model = current.model;
+      if (model) {
+        
+        const riseMetadata = (model.getMetadata('rise') as any) || {};
+        
+        riseMetadata['theme'] = themeName;
+        model.setMetadata('rise', riseMetadata);
+        
+        
+        showDialog({
+          title: trans.__('Theme Updated'),
+          body: trans.__(`Theme set to "${themeName}". Please save and refresh to apply changes.`),
+          buttons: [Dialog.okButton()]
+        });
+      }
+    }
+    document.body.classList.add('rise-enabled');
+  }
+});
+
+
+// Inside the activate function
+commands.addCommand(CommandIDs.openThemePicker, {
+  label: trans.__('Select RISE Theme'),
+  caption: trans.__('Open a visual dialog to choose a Reveal.js theme'),
+execute: async () => {
+  const current = notebookTracker.currentWidget;
+  if (!current) return;
+
+  await showDialog({ 
+    title: trans.__('Choose a Slideshow Theme'),
+    body: new ThemePickerDialog(trans, notebookTracker), 
+    buttons: [Dialog.okButton({ label: trans.__('Close') })]
+  });
+}
+});
+
     notebookTracker.widgetAdded.connect(
       async (sender: INotebookTracker, panel: NotebookPanel) => {
         panel.toolbar.insertBefore(
@@ -349,6 +424,9 @@ const plugin: JupyterFrontEndPlugin<IRisePreviewTracker> = {
         // Don't trigger auto launch in stand-alone Rise application.
         if (app.name !== 'Rise') {
           await panel.context.ready;
+          const riseData = (panel.content.model?.getMetadata('rise') as any) || {};
+          const initialTheme = riseData.theme || 'black';
+        document.body.setAttribute('data-rise-theme', initialTheme);
 
           let autolaunch: boolean =
             (panel.content.model?.getMetadata('rise') ?? {})['autolaunch'] ??
@@ -364,7 +442,22 @@ const plugin: JupyterFrontEndPlugin<IRisePreviewTracker> = {
             });
           }
         }
+        // Include a second Button for in the toolbar for theme:
+panel.toolbar.insertBefore(
+  'kernelName',
+  'RISE-theme-button',
+  new CommandToolbarButton({
+    commands,
+    id: CommandIDs.openThemePicker,
+    icon: paletteIcon, // colorpalette-Icon
+    caption: trans.__('Select RISE Theme') // Tooltip
+  })
+);
+
+
       }
+
+
     );
 
     if (palette) {

--- a/packages/lab/style/index.css
+++ b/packages/lab/style/index.css
@@ -1,1 +1,142 @@
-@import url('base.css');
+/** Index.css
+* Base styles shared across the extension.
+*
+*
+*Purpose:
+*  - Layout and interaction styles for the ThemePickerDialog
+*   - Displays available Reveal.js themes in a responsive grids. 
+*/
+
+
+/* define the color global based on the attributes of the body or fullscreen elements */
+
+:root {
+/* light themes */
+    --rise-bg-white: #ffffff;
+    --rise-bg-simple: #ffffff;
+    --rise-bg-sky: #f7fbfc;
+    --rise-bg-beige: #f7f2d3;
+    --rise-bg-solarized: #fdf6e3;
+    --rise-bg-serif: #f0f1eb;
+
+    /* dark themes */
+    --rise-bg-black: #191919;
+    --rise-bg-night: #111111;
+    --rise-bg-moon: #002b36;
+    --rise-bg-blood: #222222;
+    --rise-bg-league: #2b2b2b;
+   /* --rise-bg-dracula: #282a36;*/
+
+}
+
+/* Set jupyter lab transparent for visibility of the theme background */
+body.rise-enabled .lm-Widget,
+body.rise-enabled .jp-Notebook,
+body.rise-enabled .jp-Cell {
+    background: transparent !important;
+    background-color: transparent !important;
+}
+
+/* Set the help dialog when theme is active white*/
+.jp-Dialog .jp-Dialog-content,
+div.jp-Dialog-content.lm-Widget, 
+.font-size-dialog-container,
+.rise-help-dialog-container {
+    background: white !important;
+    background-color: white !important;
+    opacity: 1 !important;
+    color: #333 !important;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5) !important;
+}
+
+
+/* Styling for lists in help-dialog */
+.rise-help-dialog-container ul {
+    list-style-type: disc !important;
+    padding-left: 25px !important;
+    color: #333 !important;
+}
+
+/* Set font size dialog white */
+.font-size-dialog-container div {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    align-items: center;
+}
+
+/* Stops transparent side effect in righ-click menu*/
+.lm-Widget.lm-Menu,
+.lm-Widget.lm-Menu.lm-Widget {
+    background-color: #ffffff !important; /* white background  */
+    color: #333333 !important;           /* dark text */
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2) !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+}
+
+/* repair the Hover effect in menu */
+.lm-Menu-item.lm-mod-active {
+    background-color: #e0e0e0 !important;
+}
+
+/* color of of the Shortcut text in menu */
+.lm-Menu-itemShortcut {
+    color: #666666 !important;
+}
+
+
+/*Select themes their background-color */
+body[data-rise-theme='black'] { background-color: var(--rise-bg-black) !important; }
+body[data-rise-theme='white'] { background-color: var(--rise-bg-white) !important; }
+body[data-rise-theme='simple'] { background-color: var(--rise-bg-simple) !important; }
+body[data-rise-theme='sky'] { background-color: var(--rise-bg-sky) !important; }
+body[data-rise-theme='beige'] { background-color: var(--rise-bg-beige) !important; }
+body[data-rise-theme='blood'] { background-color: var(--rise-bg-blood) !important; }
+body[data-rise-theme='night'] { background-color: var(--rise-bg-night) !important; }
+body[data-rise-theme='moon'] { background-color: var(--rise-bg-moon) !important; }
+body[data-rise-theme='league'] { background-color: var(--rise-bg-league) !important; }
+/*body[data-rise-theme='dracula'] { background-color: var(--rise-bg-dracula) !important; }*/
+body[data-rise-theme='solarized'] { background-color: var(--rise-bg-solarized) !important; }
+body[data-rise-theme='serif'] { background-color: var(--rise-bg-serif) !important; }
+
+
+
+/* Set reveal element transparent */
+.reveal, 
+.reveal .slides, 
+.reveal .slides section,
+iframe.rise-Preview-iframe {
+    background-color: transparent !important;
+}
+
+/*Set element in fullscreen into his backgroundcolor based on their body*/
+
+:fullscreen, :-webkit-full-screen {
+    background-color: inherit !important; 
+}
+
+/* Otherwise set the background black*/
+::backdrop {
+    background-color: inherit !important;
+}
+
+/* Theme Picker UI  */
+
+
+.rise-ThemePicker-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.rise-ThemePicker-item {
+  cursor: pointer;
+  text-align: center;
+  transition: transform 0.2s ease;
+}
+
+.rise-ThemePicker-item:hover {
+  transform: scale(1.05);
+}
+


### PR DESCRIPTION
## Description

This PR introduces a new Theme Picker feature for the JupyterLab RISE extension. It allows users to visually select and apply reveal.js themes directly from the notebook toolbar.

## Features:


-Functions correctly and harmonizes fully with all existing features (Font Size Menu, Chalkboard, Shortcut Menu, Help Dialog Menu)

- New UI Component: Added ThemePickerDialog (React-based) featuring a grid of 11 standard Reveal.js themes.

- Metadata Integration: Automatically updates the rise.theme metadata in the notebook's JSON structure.

- Auto-Refresh Logic: Implemented an iframe refresh mechanism that reloads the RISE preview immediately after a theme is selected.

- UI/UX Improvements: Added a toolbar button with the RISE icon for easy access.


#### Supported Themes:(https://revealjs.com/themes/)
Included: Black, White, Simple, Sky, Beige, Blood, Night, Moon, League, Solarized, and Serif.

## Changes in the files:

- packages/application/style/index.css
- packages\lab\src\ThemePicker.tsx
- packages\lab\src\index.ts
-  packages/application/src/plugins/rise.ts

       

## How to Test:

1. Open a notebook and click the new "Select RISE Theme" button in the toolbar.
2. Open the RISE  Slideshow .
3. Select a dark theme (e.g., Dracula or Blood).
4. Verify: The status message should update
5. Refresh the Reveal slideshow


## Screenshots:

<img width="341" height="38" alt="image" src="https://github.com/user-attachments/assets/746a32eb-7f0c-458c-aa5a-03f34c2a859e" />

<img width="553" height="322" alt="image" src="https://github.com/user-attachments/assets/20f83f0b-243d-49f6-9d76-fbe58da0c5a9" />


#### In Fullscreen-mode:
<img width="1204" height="608" alt="image" src="https://github.com/user-attachments/assets/526cae56-615e-4497-b061-7087cea6448c" />


#### In cooperation  with other feature:

<img width="687" height="508" alt="image" src="https://github.com/user-attachments/assets/5e5a5f0b-3d3f-4c98-82d4-b01c710f856d" />
<img width="1883" height="1024" alt="image" src="https://github.com/user-attachments/assets/ad5f00b7-d3df-4988-a800-6dab27697c08" />
<img width="664" height="674" alt="image" src="https://github.com/user-attachments/assets/aadbe50b-2961-4811-a28c-f5a3047afa54" />
<img width="732" height="668" alt="image" src="https://github.com/user-attachments/assets/34fc1908-7907-46b8-a08b-63246ff9225a" />



